### PR TITLE
feat: changed bucket name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "s3_bucket" {
-    bucket = var.bucket_name
+    bucket = "${var.service_name}-backups"
     acl = "private"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-output "bucket_name" {
+output "bucket_arn" {
     value = aws_s3_bucket.s3_bucket.arn
     description = "The arn of the bucket created."
 }

--- a/tests/integration/main.tf
+++ b/tests/integration/main.tf
@@ -15,7 +15,6 @@ terraform {
 module "s3-backup-bucket" {
     source = "../.."
 
-    service_name = "integration_tests"
-    bucket_name = "systemsmystery-test-bucket-${formatdate("DDMMYYYY-hhmmss", timestamp())}"
+    service_name = "integration-tests-${formatdate("DDMMYYYY-hhmmss", timestamp())}"
     pgp_key = "keybase:richard_annand"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,5 @@
 variable "service_name" {
-    description = "Name of service to use for user and policy name"
-    default = ""
-}
-
-variable "bucket_name" {
-    description = "The name of the bucket to use"
+    description = "Name of service to use for user and policy name. This will be used to name the IAM user, policy and bucket."
     default = ""
 }
 


### PR DESCRIPTION
changed the way the bucket name is created, now uses the service_name and appends backups. Change
output to bucket_arn

BREAKING CHANGE: changed bucket name, bucket_name variable removed, uses service_name and appends
backups to the end of service name; output for bucket is now called bucket_arn.